### PR TITLE
Fixing a bad resource reference

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -213,7 +213,7 @@ def generate_cf_template():
                             [
                                 "arn:aws:s3:::",
                                 {
-                                    "Ref": "website_bucket",
+                                    "Ref": "WebsiteS3Bucket",
                                 },
                                 "/*"
                             ]


### PR DESCRIPTION
I'm guessing this was a copy/paste or search/replace bug but the "website_bucket" reference was wrong. It should be "WebsiteS3Bucket".